### PR TITLE
Fix Logger bug and make tests care about precise values

### DIFF
--- a/mat/cubic_magnetometer.py
+++ b/mat/cubic_magnetometer.py
@@ -20,7 +20,7 @@ class CubicMagnetometer(Meter):
         self.soft_iron = array_from_tags(hs,
                                          X_KEYS,
                                          Y_KEYS,
-                                         Z_KEYS).transpose()
+                                         Z_KEYS)
 
     def convert(self, raw_magnetometer, temperature=None):
         return dot(self.soft_iron, raw_magnetometer + self.hard_iron)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from numpy import array
+from numpy.testing import assert_array_almost_equal
 from mat.converter import Converter
 from mat.cubic_accelerometer import CubicAccelerometer
 from mat.cubic_magnetometer import CubicMagnetometer
@@ -8,17 +9,36 @@ from mat.linear_accelerometer import LinearAccelerometer
 from mat.pressure import DEFAULT_PRA
 from mat.temp_compensated_magnetometer import TempCompensatedMagnetometer
 from mat.v3_calibration import V3Calibration
-from utils import (
-    calibration_from_file,
-)
+from utils import calibration_from_file
 
 
-ZERO_ARRAY = array([0])
-TEMP_ARRAY = array([1])
 EXAMPLE_RAW_DATA = array([[1, 2, 3, 4],
                           [5, 6, 7, 8],
                           [9, 10, 11, 12]])
 EXAMPLE_TEMP_ARRAY = array([1, 1, 1, 1])
+CUBIC_ACCELEROMETER_EXPECTATION = array(
+    [[-0.052881, -0.053123, -0.053364, -0.053605],
+     [-0.023976, -0.024236, -0.024496, -0.024755],
+     [-0.044227, -0.044491, -0.044755, -0.045019]])
+CUBIC_MAGNETOMETER_EXPECTATION = array(
+    [[ -667.08790764,  -665.97841294,  -664.86891823,  -663.75942353],
+     [-1930.41903643, -1929.34010623, -1928.26117604, -1927.18224584],
+     [-2298.89591205, -2297.79603673, -2296.69616142, -2295.59628611]])
+LINEAR_ACCELEROMETER_EXPECTATION = array(
+    [[-0.000977, -0.001953, -0.00293 , -0.003906],
+     [-0.004883, -0.005859, -0.006836, -0.007812],
+     [-0.008789, -0.009766, -0.010742, -0.011719]])
+TCM_EXPECTATION = array(
+    [[-448.188964,  -446.993222,  -445.79748,  -444.601739],
+     [-5258.577008, -5257.446861, -5256.316713, -5255.186566],
+     [-4588.130654, -4586.98616, -4585.841665, -4584.697171]])
+TCM_NO_TEMP_EXPECTATION = array(
+    [[-382.623668,  -381.427926,  -380.232185,  -379.036443],
+     [-5052.676622, -5051.546475, -5050.416327, -5049.28618],
+     [-4424.023578, -4422.879083, -4421.734589, -4420.590094]])
+TEMP_ARRAY = array([1])
+TEMPERATURE_EXPECTATION = array([1194.08902837])
+ZERO_ARRAY = array([0])
 
 
 class TestConverter(TestCase):
@@ -27,14 +47,14 @@ class TestConverter(TestCase):
             Converter(V3Calibration({}))
 
     def test_calibrated_temperature(self):
-        assert Converter(
+        assert_array_almost_equal(Converter(
             calibration_from_file("v3_calibration.txt")).temperature(
-                TEMP_ARRAY).shape == (1, )
+                TEMP_ARRAY), TEMPERATURE_EXPECTATION)
 
     def test_calibrated_pressure(self):
         assert Converter(
             calibration_from_file("v3_calibration.txt")).pressure(
-            ZERO_ARRAY) == array([DEFAULT_PRA])
+                ZERO_ARRAY) == array([DEFAULT_PRA])
 
     def test_calibrated_light(self):
         assert Converter(
@@ -50,13 +70,15 @@ class TestConverter(TestCase):
         converter = Converter(calibration_from_file("v2_linear_acc.txt"))
         assert isinstance(converter.accelerometer_converter,
                           LinearAccelerometer)
-        assert converter.accelerometer(EXAMPLE_RAW_DATA).shape == (3, 4)
+        assert_array_almost_equal(converter.accelerometer(EXAMPLE_RAW_DATA),
+                                  LINEAR_ACCELEROMETER_EXPECTATION)
 
     def test_calibrated_cubic_accelerometer(self):
         converter = Converter(calibration_from_file("v3_calibration.txt"))
         assert isinstance(converter.accelerometer_converter,
                           CubicAccelerometer)
-        assert converter.accelerometer(EXAMPLE_RAW_DATA).shape == (3, 4)
+        assert_array_almost_equal(converter.accelerometer(EXAMPLE_RAW_DATA),
+                                  CUBIC_ACCELEROMETER_EXPECTATION)
 
     def test_missing_magnetometer(self):
         assert Converter(
@@ -67,17 +89,20 @@ class TestConverter(TestCase):
         converter = Converter(calibration_from_file("v3_calibration.txt"))
         assert isinstance(converter.magnetometer_converter,
                           CubicMagnetometer)
-        assert converter.magnetometer(EXAMPLE_RAW_DATA).shape == (3, 4)
+        assert_array_almost_equal(converter.magnetometer(EXAMPLE_RAW_DATA),
+                                  CUBIC_MAGNETOMETER_EXPECTATION)
 
     def test_calibrated_temp_comp_magnetometer_with_no_temp(self):
         converter = Converter(calibration_from_file("v3_temp_comp.txt"))
         assert isinstance(converter.magnetometer_converter,
                           TempCompensatedMagnetometer)
-        assert converter.magnetometer(EXAMPLE_RAW_DATA).shape == (3, 4)
+        assert_array_almost_equal(converter.magnetometer(EXAMPLE_RAW_DATA),
+                                  TCM_NO_TEMP_EXPECTATION)
 
     def test_calibrated_temp_comp_magnetometer(self):
         converter = Converter(calibration_from_file("v3_temp_comp.txt"))
         assert isinstance(converter.magnetometer_converter,
                           TempCompensatedMagnetometer)
-        assert converter.magnetometer(EXAMPLE_RAW_DATA,
-                                      EXAMPLE_TEMP_ARRAY).shape == (3, 4)
+        assert_array_almost_equal(converter.magnetometer(EXAMPLE_RAW_DATA,
+                                                         EXAMPLE_TEMP_ARRAY),
+                                  TCM_EXPECTATION)


### PR DESCRIPTION
To test:
- Run tests in lowell-mat and see them pass
- Rebuild Logger and see it's tests fail.
- Change the requirements.txt in Logger to use the mat-31 branch for lowell-mat and see tests succeed.
