### PR TITLE
Reduce conversion time

### DIFF
--- a/mat/sensor.py
+++ b/mat/sensor.py
@@ -1,6 +1,7 @@
 from mat.sensor_specification import AVAILABLE_SENSORS
 import numpy as np
 from math import floor
+from heapq import merge
 
 
 def create_sensors(header, calibration, seconds):
@@ -42,8 +43,8 @@ def _time_and_order(sensors):
     for sensor in sensors:
         sample_times = sensor.full_sample_times()
         sensor_time_order = [(t, sensor.order) for t in sample_times]
-        time_and_order.extend(sensor_time_order)
-    return sorted(time_and_order)
+        time_and_order.append(sensor_time_order)
+    return list(merge(*time_and_order))
 
 
 def _load_sequence_into_sensors(sensors, time_and_order):
@@ -76,18 +77,21 @@ class Sensor:
         self.order = sensor_spec.order
         self.converter = sensor_spec.converter(calibration)
         self.cache = {'page_time': None, 'data': None}
+        self._full_sample_times_cache = None
 
     def full_sample_times(self):
         """
         The elapsed time in seconds from the start of the data page when a
         sensor samples. n channel sensors return n times per sample.
         """
-        sample_times = []
-        for interval_time in range(0, self.seconds, self.interval):
-            for burst_time in range(0, self.burst_count):
-                burst_time = [interval_time + burst_time / self.burst_rate]
-                sample_times.extend([burst_time] * self.channels)
-        return np.array(sample_times)
+        if self._full_sample_times_cache is None:
+            sample_times = []
+            for interval_time in range(0, self.seconds, self.interval):
+                for burst_time in range(0, self.burst_count):
+                    burst_time = [interval_time + burst_time / self.burst_rate]
+                    sample_times.extend([burst_time] * self.channels)
+            self._full_sample_times_cache = sample_times
+        return self._full_sample_times_cache
 
     def _parse_page(self, data_page):
         """

--- a/mat/sensor.py
+++ b/mat/sensor.py
@@ -2,6 +2,7 @@ from mat.sensor_specification import AVAILABLE_SENSORS
 import numpy as np
 from math import floor
 from heapq import merge
+from itertools import chain
 
 
 def create_sensors(header, calibration, seconds):
@@ -85,12 +86,10 @@ class Sensor:
         sensor samples. n channel sensors return n times per sample.
         """
         if self._full_sample_times_cache is None:
-            sample_times = []
-            for interval_time in range(0, self.seconds, self.interval):
-                for burst_time in range(0, self.burst_count):
-                    burst_time = [interval_time + burst_time / self.burst_rate]
-                    sample_times.extend([burst_time] * self.channels)
-            self._full_sample_times_cache = sample_times
+            times = [[interval+burst/self.burst_rate]*self.channels
+                     for interval in range(0, self.seconds, self.interval)
+                     for burst in range(self.burst_count)]
+            self._full_sample_times_cache = list(chain.from_iterable(times))
         return self._full_sample_times_cache
 
     def _parse_page(self, data_page):

--- a/mat/sensor_data_file.py
+++ b/mat/sensor_data_file.py
@@ -74,7 +74,9 @@ class SensorDataFile(ABC):
             return self._partial_page_seconds()
 
     def samples_per_page(self):
-        return self._count_samples(self.sensors())
+        if self._samples_per_page is None:
+            self._samples_per_page = self._count_samples(self.sensors())
+        return self._samples_per_page
 
     def _count_samples(self, sensor_list):
         samples = 0


### PR DESCRIPTION
By making several small changes to sensor and sensor_data_file, conversion time has been reduced from 40.7 seconds to 6.1 seconds for a 20 MB sample file. Specifically, time values were caches, and a heapq.merge was substituted for the .sorted() method as the input arrays to be merged were themselves already sorted. All tests are passing, coverage at 100%